### PR TITLE
chore: fixing typo in faucet.json

### DIFF
--- a/src/data/faucets.json
+++ b/src/data/faucets.json
@@ -46,7 +46,7 @@
       "amounts": [10, 20, 30],
       "url": "http://faucet-github.test6.testnets.gno.land",
       "description": "Debuggable Test6 Github Faucet Drip",
-      "github_oauth_client_id": "Ov23ligBo4yDWMcoZaKF"
+      "github_oauth_client_id": "Ov23ligBo4yDWMcoZaKF",
       "debug": true
     }
     


### PR DESCRIPTION
adding missing comma in an item