### PR TITLE
(WIP)feat: json-rpc 2.0 faucet API

### DIFF
--- a/src/composables/useFaucetApi.ts
+++ b/src/composables/useFaucetApi.ts
@@ -1,0 +1,95 @@
+import { Faucet } from '@/types'
+
+interface JSONRPCResponse {
+  jsonrpc: '2.0'
+  id: number
+  result?: string
+  error?: {
+    code: number
+    message: string
+  }
+}
+
+interface FaucetRequestOptions {
+  address: string
+  amount?: string  // Changed to string to accept ugnot directly
+  captchaSecret?: string
+  githubCode?: string
+}
+
+export function useFaucetApi() {
+  const MIN_LOADING_TIME = 2000 // 2 seconds minimum loading time for UI
+
+  const createJSONRPCRequest = (options: FaucetRequestOptions) => {
+    const { address, amount, captchaSecret } = options
+    const request = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'drip',
+      params: [
+        address,
+        amount, 
+      ],
+      meta: captchaSecret ? { captcha: captchaSecret } : undefined,
+    }
+    return request
+  }
+
+  const handleResponse = async (response: Response): Promise<string> => {
+    const contentType = response.headers.get('content-type')
+
+    if (contentType?.includes('text/')) {
+      // Handle text response (HTTP error)
+      const text = await response.text()
+      console.log('Received text error:', text)
+      throw new Error(text)
+    }
+
+    if (!contentType?.includes('application/json')) {
+      throw new Error('Unexpected response content type')
+    }
+
+    // Handle JSON-RPC response
+    const jsonResponse = await response.json() as JSONRPCResponse
+
+    if (jsonResponse.error) {
+      console.log('JSON-RPC error:', jsonResponse.error)
+      throw new Error(jsonResponse.error.message || 'Unknown JSON-RPC error')
+    }
+
+    if (!jsonResponse.result) {
+      throw new Error('Invalid JSON-RPC response: missing result')
+    }
+
+    return jsonResponse.result
+  }
+
+  const requestFaucet = async (faucet: Faucet, options: FaucetRequestOptions): Promise<string> => {
+    const minTimer = new Promise((resolve) => setTimeout(resolve, MIN_LOADING_TIME))
+
+    try {
+      const url = options.githubCode 
+        ? `${faucet.url}?code=${options.githubCode}`
+        : faucet.url
+      
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(createJSONRPCRequest(options)),
+      })
+
+      const result = await handleResponse(response)
+      await minTimer // Ensure minimum loading time for UI
+      return result
+    } catch (e) {
+      await minTimer // Ensure minimum loading time for UI
+      throw e
+    }
+  }
+
+  return {
+    requestFaucet,
+  }
+} 

--- a/src/stores/faucetDetail.ts
+++ b/src/stores/faucetDetail.ts
@@ -4,6 +4,8 @@ import { CustomEase } from 'gsap/CustomEase'
 import { CSSPlugin } from 'gsap/CSSPlugin'
 import { RequestStatus, Faucet } from '@/types'
 import { watch, nextTick } from 'vue'
+import { useFaucetApi } from '@/composables/useFaucetApi'
+import { convertToUgnot } from '@/utils/amount'
 
 // Register GSAP plugins
 gsap.registerPlugin(CustomEase, CSSPlugin)
@@ -206,32 +208,15 @@ export const useFaucetDetail = defineStore('faucetDetail', {
     async requestWithCaptcha(address: string, amount?: number, captchaSecret?: string) {
       await this.handleRequestAnimation()
 
-      // min default loading timer
-      const minTimer = new Promise((resolve) => setTimeout(resolve, MIN_LOADING_TIME))
-
       try {
-        const response = await fetch(this.selectedFaucet.url, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            to: address,
-            amount: amount ? amount * 1000000 + 'ugnot' : undefined,
-            captcha: captchaSecret,
-          }),
+        const { requestFaucet } = useFaucetApi()
+        await requestFaucet(this.selectedFaucet, {
+          address,
+          amount: amount ? convertToUgnot(amount) : undefined,
+          captchaSecret,
         })
-
-        await minTimer // Ensure minimum loading time
-        const faucetResponse = await response.json()
-
-        if (response.status === 200 && !faucetResponse.error) {
-          await this.handleRequestSuccess()
-        } else {
-          await this.handleRequestError(faucetResponse.error)
-        }
+        await this.handleRequestSuccess()
       } catch (e) {
-        await minTimer // Ensure minimum loading time even on error
         await this.handleRequestError(e instanceof Error ? e.message : String(e))
       }
     },
@@ -285,38 +270,15 @@ export const useFaucetDetail = defineStore('faucetDetail', {
 
       localStorage.setItem('last-code', code!)
 
-      // min default loading timer
-      const minTimer = new Promise((resolve) => setTimeout(resolve, MIN_LOADING_TIME))
-
       try {
-        // If not in local dev mode, proceed with actual API call
-        const fetchPromise = fetch(`${storage.url}?code=${code}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            to: storage.address,
-            amount: parseInt(storage.value!, 10) * 1000000 + 'ugnot', //TODO: need to be dynamic if different token
-          }),
+        const { requestFaucet } = useFaucetApi()
+        await requestFaucet(this.selectedFaucet, {
+          address: storage.address!,
+          amount: convertToUgnot(parseInt(storage.value!, 10)),
+          githubCode: code!,
         })
-
-        const response = (await Promise.race([
-          fetchPromise,
-          // Timeout after 10s
-          new Promise((_, reject) => setTimeout(() => reject(new Error('Request timeout')), 10000)),
-        ])) as Response
-
-        await minTimer // Ensure minimum loading time
-        const faucetResponse = await response.json()
-
-        if (response.status === 200 && !faucetResponse.error) {
-          await this.handleRequestSuccess()
-        } else {
-          await this.handleRequestError(faucetResponse.error || 'Request failed')
-        }
+        await this.handleRequestSuccess()
       } catch (e) {
-        await minTimer // Ensure minimum loading time even on error
         await this.handleRequestError(e instanceof Error ? e.message : String(e))
       }
     },

--- a/src/utils/amount.ts
+++ b/src/utils/amount.ts
@@ -1,0 +1,7 @@
+export const convertToUgnot = (amount: number): string => {
+  return `${amount * 1000000}ugnot`
+}
+
+export const convertFromUgnot = (ugnot: string): number => {
+  return parseInt(ugnot.replace('ugnot', ''), 10) / 1000000
+} 


### PR DESCRIPTION
⚠️ WIP: Update Faucet API to JSON-RPC 2.0 Standard

## Changes
- Created new `useFaucetApi` composable to handle JSON-RPC 2.0 communication and separate API from store
- Added `amount.ts` utility for ugnot conversions.  
- Updated faucet requests to follow JSON-RPC 2.0 format
- Improved error handling for API responses

## JSON-RPC 2.0 Format

Folowwing  https://github.com/gnolang/gno/pull/4303 requirements, requests now follow the standard format:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "drip",
  "params": [
    "g1e6gxg5tvc55mwsn7t7dymmlasratv7mkv0rap2",
    "1000ugnot"
  ]
}
```

### Response Handling
- Text responses are treated as HTTP errors
- JSON responses are parsed as JSON-RPC 2.0 objects
- Proper error handling for both HTTP and JSON-RPC errors

### Code Organization
- Separated API communication logic into `useFaucetApi` composable
- Created pure utility functions for amount conversions in `amount.ts`
- Maintained UI state management in the store
